### PR TITLE
Final blank excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PolishGeeks Dev Tools Changelog
 
+## 1.1.2
+
+- Ignore .DS_Store files in FinalBlankLine validator
+
 ## 1.1.1
 
 - Ignore doc directory in FinalBlankLine validator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.1.2
 
-- Ignore .DS_Store files in FinalBlankLine validator
+- Ignore .DS_Store files in FinalBlankLine validator.
+- Changed FinalBlankLine excluded mechanism. You can define directories and files (ex. lib/command or lib/file.rb). Please don't use path with stars convention (ex. lib/**/*).
 
 ## 1.1.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    polishgeeks-dev-tools (1.1.1)
+    polishgeeks-dev-tools (1.1.2)
       brakeman
       faker
       haml-lint
@@ -148,7 +148,7 @@ GEM
       reek (= 1.6.3)
       ruby2ruby (>= 2.1.1, < 3.0)
       virtus (~> 1.0)
-    sass (3.4.17)
+    sass (3.4.18)
     sexp_processor (4.6.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ determine, which you can use in your project:
 
 Some validators might accept additional config settings - please refer to this table for a description on how to use them:
 
-| Option                        | Validator             | Description                                                                                         |
-|-------------------------------|-----------------------|-----------------------------------------------------------------------------------------------------|
-| rspec_files_structure_ignored | rspec_files_structure | You can provide an array of files that should be ignored                                            |
-| final_blank_line_ignored      | final_blank_line      | You can provide an array of files or directories that should be ignored                             |
+| Option                        | Validator             | Description                                                                                                 |
+|-------------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------|
+| rspec_files_structure_ignored | rspec_files_structure | You can provide an array of files that should be ignored                                                    |
+| final_blank_line_ignored      | final_blank_line      | You can provide an array of files (ex. lib/file.rb) or directories (ex. lib/command) that should be ignored |
 
 ## Usage in any Rails/Ruby application
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some validators might accept additional config settings - please refer to this t
 | Option                        | Validator             | Description                                                                                         |
 |-------------------------------|-----------------------|-----------------------------------------------------------------------------------------------------|
 | rspec_files_structure_ignored | rspec_files_structure | You can provide an array of files that should be ignored                                            |
-| final_blank_line_ignored      | final_blank_line      | You can provide an array of files (ex. lib/file.rb) or paths (ex. lib/\*\*/\*) that should be ignored |
+| final_blank_line_ignored      | final_blank_line      | You can provide an array of files or directories that should be ignored                             |
 
 ## Usage in any Rails/Ruby application
 

--- a/lib/polishgeeks/dev-tools/command/final_blank_line.rb
+++ b/lib/polishgeeks/dev-tools/command/final_blank_line.rb
@@ -17,6 +17,7 @@ module PolishGeeks
           public
           app/assets/images
           app/assets/fonts
+          .DS_Store
         )
 
         # Executes this command and set output and counter variables
@@ -49,40 +50,33 @@ module PolishGeeks
         private
 
         # @return [Array<String>] array with files to analyze
+        # @note method take all not excluded files, also with hidden files
         def files_to_analyze
           # expression {*,.*} is needed because glob method don't take unix-like hidden files
-          files_from_path('**/{*,.*}') - excludes
+          files = files_from_path('**/{*,.*}')
+          remove_excludes files
         end
 
-        # @return [Array<String>] list of files that
+        # @param [Array<String>] files list which we want analyse
+        # @return [Array<String>] array without excluded files/directories
+        def remove_excludes(files)
+          excluded_paths = excludes
+          files.delete_if do |file|
+            excluded_paths.any? { |exclude| file =~ /#{exclude}/ }
+          end
+        end
+
+        # @return [Array<String>] list of files/directories that
         #   should be excluded from checking
+        # @note excluded files/directories are defined in DEFAULT_PATHS_TO_EXCLUDE
+        #   and in configuration file
         def excludes
-          (default_excludes + config_excludes).flatten
+          config_excludes + DEFAULT_PATHS_TO_EXCLUDE
         end
 
-        # @return [Array<String>] list of default excluded files
-        #   defined in DEFAULT_PATHS_TO_EXCLUDE
-        def default_excludes
-          excluded_files = []
-
-          DEFAULT_PATHS_TO_EXCLUDE.each do |path|
-            excluded_files << files_from_path("#{path}/**/{*,.*}")
-          end
-
-          excluded_files
-        end
-
-        # @return [Array<String>] list of excluded files from config file
+        # @return [Array<String>] list of excluded files/directories from config file
         def config_excludes
-          excluded_files = []
-          config_paths = DevTools.config.final_blank_line_ignored
-          return [] unless config_paths
-
-          config_paths.each do |path|
-            excluded_files << files_from_path(path)
-          end
-
-          excluded_files
+          DevTools.config.final_blank_line_ignored || []
         end
 
         # @param [String] path from which we want take files

--- a/lib/polishgeeks/dev-tools/command/final_blank_line.rb
+++ b/lib/polishgeeks/dev-tools/command/final_blank_line.rb
@@ -58,7 +58,7 @@ module PolishGeeks
         end
 
         # @param [Array<String>] files list which we want analyse
-        # @return [Array<String>] array without excluded files/directories
+        # @return [Array<String>] array without excluded files
         def remove_excludes(files)
           excluded_paths = excludes
           files.delete_if do |file|

--- a/lib/polishgeeks/dev-tools/version.rb
+++ b/lib/polishgeeks/dev-tools/version.rb
@@ -3,6 +3,6 @@ module PolishGeeks
   # Dev Tools for PolishGeeks developers
   module DevTools
     # Current version of dev tools
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/spec/lib/polishgeeks/dev-tools/command/final_blank_line_spec.rb
+++ b/spec/lib/polishgeeks/dev-tools/command/final_blank_line_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe PolishGeeks::DevTools::Command::FinalBlankLine do
 
   describe '#excludes' do
     let(:configs) { [rand.to_s] }
-    let(:expected) { (configs + described_class::DEFAULT_PATHS_TO_EXCLUDE).flatten }
+    let(:expected) { configs + described_class::DEFAULT_PATHS_TO_EXCLUDE }
 
     before do
       expect(subject)


### PR DESCRIPTION
It was not possible to add .DS_Store excluded in current FinalBlankLine validator. So, I've changed excluded mechanism similar to ExpiresIn validator. From now, validator will exclude files and directories with comparison by regular expression. It'll be more elastic for us to exclude next default paths and easier for users, because they can use ex. lib/command instead of lib/command/**/* expression. 