### PR TITLE
Handle case when dedicated config file is missing

### DIFF
--- a/lib/polish_geeks/dev_tools/commands/examples_comparator.rb
+++ b/lib/polish_geeks/dev_tools/commands/examples_comparator.rb
@@ -13,8 +13,12 @@ module PolishGeeks
 
           Dir[config_path].each do |example_file|
             dedicated_file = example_file.gsub('.example', '')
-            header = compare_header(example_file, dedicated_file)
-            @output << compare_output(header, example_file, dedicated_file)
+            if File.exist?(dedicated_file)
+              header = compare_header(example_file, dedicated_file)
+              @output << compare_output(header, example_file, dedicated_file)
+            else
+              @output << missing_file(dedicated_file)
+            end
           end
         end
 
@@ -74,6 +78,12 @@ module PolishGeeks
         # @return [String] failed message for single file
         def failed_compare(compare_header)
           "\e[31m failed\e[0m - #{compare_header} - structure not equal\n"
+        end
+
+        # @param [String] dedicated_file path to config file which is missing
+        # @return [String] failed message for missing file
+        def missing_file(dedicated_file)
+          "\e[31m failed\e[0m - #{File.basename(dedicated_file)} - file is missing\n"
         end
       end
     end

--- a/spec/lib/polish_geeks/dev_tools/commands/examples_comparator_spec.rb
+++ b/spec/lib/polish_geeks/dev_tools/commands/examples_comparator_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe PolishGeeks::DevTools::Commands::ExamplesComparator do
   subject { described_class.new }
 
   let(:example_file) { rand.to_s }
-  let(:dedicated_file) { rand.to_s }
+  let(:dedicated_file) { example_file }
+  let(:dedicated_file_present) { true }
 
   describe '#execute' do
     let(:config_path) { rand.to_s }
@@ -14,18 +15,25 @@ RSpec.describe PolishGeeks::DevTools::Commands::ExamplesComparator do
         .to receive(:config_path)
         .and_return(config_path)
 
-      expect(subject)
-        .to receive(:same_key_structure?)
-        .and_return(compare_result)
-
       expect(Dir)
         .to receive(:[])
         .with(config_path)
         .and_return([example_file])
+
+      expect(File)
+        .to receive(:exist?)
+        .with(dedicated_file)
+        .and_return(dedicated_file_present)
     end
 
     context 'when compared files structure is the same' do
       let(:compare_result) { true }
+
+      before do
+        expect(subject)
+          .to receive(:same_key_structure?)
+          .and_return(compare_result)
+      end
 
       it 'puts a successful message into output' do
         subject.execute
@@ -37,9 +45,24 @@ RSpec.describe PolishGeeks::DevTools::Commands::ExamplesComparator do
     context 'when compared files structure is not the same' do
       let(:compare_result) { false }
 
+      before do
+        expect(subject)
+          .to receive(:same_key_structure?)
+          .and_return(compare_result)
+      end
+
       it 'puts a failed message into output' do
         subject.execute
         expect(subject.output).to include 'failed'
+      end
+    end
+
+    context 'when dedicated file is not present' do
+      let(:dedicated_file_present) { false }
+
+      it 'puts a failed message into output' do
+        subject.execute
+        expect(subject.output).to include 'file is missing'
       end
     end
   end


### PR DESCRIPTION
Running check prints:
```bash
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - .../config/sidekiq.yml
```
This commits fixes it.
