### PR TITLE
Commands::Rspec does not catch single rspec failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - Remove dependency for mongoid-rspec
+- #54: Fix Command::Rspec to handle single test failure
 
 ## 1.3.0 (03/04/2016)
 

--- a/lib/polish_geeks/dev_tools/commands/rspec.rb
+++ b/lib/polish_geeks/dev_tools/commands/rspec.rb
@@ -9,7 +9,7 @@ module PolishGeeks
         # Regexp used to match Rspec examples count
         EXAMPLES_REGEXP = /(\d+) examples/
         # Regexp used to match Rspec failures
-        FAILURES_REGEXP = /(\d+) failures/
+        FAILURES_REGEXP = /(\d+) failure/
         # Regexp used to match Rspec pendings
         PENDING_REGEXP = /(\d+) pending/
 

--- a/spec/lib/polish_geeks/dev_tools/commands/rspec_files_structure_spec.rb
+++ b/spec/lib/polish_geeks/dev_tools/commands/rspec_files_structure_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe PolishGeeks::DevTools::Commands::RspecFilesStructure do
     it { expect(subject.send(:analyzed_files)).not_to be_empty }
 
     context 'when we gather files for analyze' do
-      let(:file) { Tempfile.new }
+      let(:file) { Tempfile.new('tempfile') }
       let(:files_collection) { [file] }
 
       before { expect(subject).to receive(:checked_files) { files_collection } }

--- a/spec/lib/polish_geeks/dev_tools/commands/rspec_spec.rb
+++ b/spec/lib/polish_geeks/dev_tools/commands/rspec_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe PolishGeeks::DevTools::Commands::Rspec do
   end
 
   describe '#valid?' do
+    context 'when there is 1 failure' do
+      before { subject.instance_variable_set(:@output, '1 failure') }
+
+      it { expect(subject.valid?).to eq false }
+    end
+
     context 'when there are failures' do
       before { subject.instance_variable_set(:@output, '2 failures') }
 


### PR DESCRIPTION
`Commands::Rspec` does not catch single rspec failure o_O

Also I've fixed `Tempfile.new` usage for Ruby 2.2.4. Without that change CI was failing with `ArgumentError: wrong number of arguments (0 for 1..2)`.