### PR TITLE
Run rubocop with --display-cop-names flag, Fixes #62

### DIFF
--- a/lib/polish_geeks/dev_tools/commands/rubocop.rb
+++ b/lib/polish_geeks/dev_tools/commands/rubocop.rb
@@ -18,6 +18,7 @@ module PolishGeeks
           cmd = ["bundle exec rubocop #{PolishGeeks::DevTools.app_root}"]
           cmd << "-c #{self.class.config_manager.path}" if self.class.config_manager.present?
           cmd << '--require rubocop-rspec' if Config.config.rubocop_rspec?
+          cmd << '--display-cop-names'
           @output = Shell.new.execute(cmd.join(' '))
         end
 

--- a/spec/lib/polish_geeks/dev_tools/commands/rubocop_spec.rb
+++ b/spec/lib/polish_geeks/dev_tools/commands/rubocop_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe PolishGeeks::DevTools::Commands::Rubocop do
       let(:cmd) do
         "bundle exec rubocop #{PolishGeeks::DevTools.app_root}" \
         " -c #{subject.class.config_manager.path}" \
-        ' --require rubocop-rspec'
+        ' --require rubocop-rspec' \
+        ' --display-cop-names'
       end
 
       before do
@@ -39,7 +40,8 @@ RSpec.describe PolishGeeks::DevTools::Commands::Rubocop do
       let(:path) { Dir.pwd }
       let(:cmd) do
         "bundle exec rubocop #{PolishGeeks::DevTools.app_root} " \
-        "-c #{subject.class.config_manager.path}"
+        "-c #{subject.class.config_manager.path} " \
+        '--display-cop-names'
       end
 
       before do


### PR DESCRIPTION
This will include more details in case of Rubocop errors, for example:
   rubocop.rb:54:1: C: Style/EmptyLines: Extra blank line detected.