### PR TITLE
Better RuboCop rules?

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
+    - Gemfile
     - bin/**/*
     - db/**/*
     - .gemspec/**/*

--- a/config/rubocop_rspec.yml
+++ b/config/rubocop_rspec.yml
@@ -3,6 +3,13 @@ RSpec/ExampleLength:
 RSpec/SubjectStub:
   Enabled: false
 RSpec/NestedGroups:
-  MaxNesting: 4
+  Max: 4
 RSpec/MessageChain:
   Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MessageSpies:
+  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*

--- a/lib/polish_geeks/dev_tools/version.rb
+++ b/lib/polish_geeks/dev_tools/version.rb
@@ -3,6 +3,6 @@ module PolishGeeks
   # Dev Tools for PolishGeeks developers
   module DevTools
     # Current version of dev tools
-    VERSION = '1.4.0'.freeze
+    VERSION = '1.4.1'.freeze
   end
 end


### PR DESCRIPTION
I made some changes to the `rubocop` rules for the project that I want to kick around and see if they make sense:

- `MaxNesting` -> `Max` 
  - Silence the warning message
- `MultipleExpectations`
  - I have seen bad tests that place multiple behavioral expectations in one `it` block, but [there exist good arguments](https://github.com/lelylan/betterspecs/issues/5#issuecomment-88939833) for not just universally applying this rule. 
- `MessageSpies`
  - For most test cases I think this one grasps at straws?
- Disable `BlockLength` in `spec` directories
  - It is not unreasonable to have a test that is ~100 LoC. 